### PR TITLE
fix check for `window` global

### DIFF
--- a/src/exports.js
+++ b/src/exports.js
@@ -2,6 +2,6 @@
 module.exports = cryptico;
 module.exports.RSAKey = RSAKey;
 
-if (typeof window !== undefined) {
+if (typeof window !== 'undefined') {
   window.cryptico = module.exports;
 }


### PR DESCRIPTION
typeof returns a string, so this test succeeded even if window is undefined.
